### PR TITLE
Support for HDFS-style checksums

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,11 @@ include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}" )
 
 add_library(XrdHdfs MODULE src/XrdHdfsBootstrap.cc src/XrdHdfsChecksum.cc src/XrdHdfsChecksumCalc.cc)
 target_link_libraries(XrdHdfs ${XROOTD_UTILS} ${DL_LIB} ${LIBCRYPTO_LIBRARIES} ${ZLIB_LIBRARIES})
+set_target_properties(XrdHdfs PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/export-lib-symbols")
 
 add_library(XrdHdfsReal MODULE src/XrdHdfs.cc src/XrdHdfsConfig.cc src/XrdHdfs.hh)
 target_link_libraries(XrdHdfsReal ${HDFS_LIB} ${XROOTD_UTILS})
+set_target_properties(XrdHdfsReal PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/export-lib-symbols")
 
 add_executable(xrootd_hdfs_envcheck src/XrdHdfsEnvCheck.cc)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,17 @@ find_package( Hdfs REQUIRED )
 find_package( Jvm REQUIRED )
 find_package( Dl REQUIRED )
 
+macro(use_cxx11)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      set (CMAKE_CXX_FLAGS "-std=gnu++11 ${CMAKE_CXX_FLAGS}")
+    endif ()
+  else ()
+    set (CMAKE_CXX_STANDARD 11)
+  endif ()
+endmacro(use_cxx11)
+use_cxx11()
+
 if( CMAKE_COMPILER_IS_GNUCXX )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror" )
 endif()
@@ -25,7 +36,7 @@ include_directories("${HDFS_INCLUDES}" "${JVM_INCLUDES}" "${JVM_MD_INCLUDES}")
 
 include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}" )
 
-add_library(XrdHdfs MODULE src/XrdHdfsBootstrap.cc XrdHdfsChecksum.cc XrdHdfsChecksumCalc.cc)
+add_library(XrdHdfs MODULE src/XrdHdfsBootstrap.cc src/XrdHdfsChecksum.cc src/XrdHdfsChecksumCalc.cc)
 target_link_libraries(XrdHdfs ${XROOTD_UTILS} ${DL_LIB})
 
 add_library(XrdHdfsReal MODULE src/XrdHdfs.cc src/XrdHdfsConfig.cc src/XrdHdfs.hh)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include_directories("${HDFS_INCLUDES}" "${JVM_INCLUDES}" "${JVM_MD_INCLUDES}")
 
 include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}" )
 
-add_library(XrdHdfs MODULE src/XrdHdfsBootstrap.cc)
+add_library(XrdHdfs MODULE src/XrdHdfsBootstrap.cc XrdHdfsChecksum.cc XrdHdfsChecksumCalc.cc)
 target_link_libraries(XrdHdfs ${XROOTD_UTILS} ${DL_LIB})
 
 add_library(XrdHdfsReal MODULE src/XrdHdfs.cc src/XrdHdfsConfig.cc src/XrdHdfs.hh)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ add_library(XrdHdfs MODULE src/XrdHdfsBootstrap.cc src/XrdHdfsChecksum.cc src/Xr
 target_link_libraries(XrdHdfs ${XROOTD_UTILS} ${DL_LIB} ${LIBCRYPTO_LIBRARIES} ${ZLIB_LIBRARIES})
 set_target_properties(XrdHdfs PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/export-lib-symbols")
 
-add_library(XrdHdfsReal MODULE src/XrdHdfs.cc src/XrdHdfsConfig.cc src/XrdHdfs.hh)
-target_link_libraries(XrdHdfsReal ${HDFS_LIB} ${XROOTD_UTILS})
+add_library(XrdHdfsReal MODULE src/XrdHdfs.cc src/XrdHdfsConfig.cc src/XrdHdfs.hh src/XrdHdfsChecksum.cc src/XrdHdfsChecksumCalc.cc)
+target_link_libraries(XrdHdfsReal ${HDFS_LIB} ${XROOTD_UTILS} ${LIBCRYPTO_LIBRARIES} ${ZLIB_LIBRARIES})
 set_target_properties(XrdHdfsReal PROPERTIES LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/export-lib-symbols")
 
 add_executable(xrootd_hdfs_envcheck src/XrdHdfsEnvCheck.cc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if( CMAKE_COMPILER_IS_GNUCXX )
 endif()
 
 if( CMAKE_COMPILER_IS_GNUCC )
-  set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror" )
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror" )
 endif()
 
 SET( CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ find_package( Hdfs REQUIRED )
 find_package( Jvm REQUIRED )
 find_package( Dl REQUIRED )
 
+include (FindPkgConfig)
+pkg_check_modules(LIBCRYPTO REQUIRED libcrypto)
+pkg_check_modules(ZLIB REQUIRED zlib)
+
 macro(use_cxx11)
   if (CMAKE_VERSION VERSION_LESS "3.1")
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
@@ -32,12 +36,12 @@ SET( CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
 SET( CMAKE_MODULE_LINKER_FLAGS "-Wl,--no-undefined")
 SET( CMAKE_EXE_LINKER_FLAGS "-Wl,--no-undefined")
 
-include_directories("${HDFS_INCLUDES}" "${JVM_INCLUDES}" "${JVM_MD_INCLUDES}")
+include_directories(${HDFS_INCLUDES} ${JVM_INCLUDES} ${JVM_MD_INCLUDES} ${LIBCRYPTO_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
 
 include_directories( "${PROJECT_SOURCE_DIR}" "${XROOTD_INCLUDES}" )
 
 add_library(XrdHdfs MODULE src/XrdHdfsBootstrap.cc src/XrdHdfsChecksum.cc src/XrdHdfsChecksumCalc.cc)
-target_link_libraries(XrdHdfs ${XROOTD_UTILS} ${DL_LIB})
+target_link_libraries(XrdHdfs ${XROOTD_UTILS} ${DL_LIB} ${LIBCRYPTO_LIBRARIES} ${ZLIB_LIBRARIES})
 
 add_library(XrdHdfsReal MODULE src/XrdHdfs.cc src/XrdHdfsConfig.cc src/XrdHdfs.hh)
 target_link_libraries(XrdHdfsReal ${HDFS_LIB} ${XROOTD_UTILS})

--- a/src/XrdHdfs.hh
+++ b/src/XrdHdfs.hh
@@ -29,6 +29,11 @@
 class XrdSfsAio;
 class XrdSysLogger;
 
+namespace XrdHdfs
+{
+    class ChecksumState;
+}
+
 #define XrdHdfsMAX_PATH_LEN 1024
 /******************************************************************************/
 /*                 X r d H d f s D i r e c t o r y                  */
@@ -137,6 +142,9 @@ unsigned long readbuf_bytes_loaded; // extra bytes in readbuf that were read fro
 	// for now, at least readbuf is protected by a mutex.  This
 	// could eventually be applied more broadly.
 XrdSysMutex readbuf_mutex;
+
+        // Keep track of checksum values for files that are being written.
+    XrdHdfs::ChecksumState *m_state;
 
     bool Connect(const XrdOucEnv &);
 };

--- a/src/XrdHdfsBootstrap.cc
+++ b/src/XrdHdfsBootstrap.cc
@@ -24,6 +24,8 @@ class XrdSysLogger;
 static XrdOss *Bootstrap(XrdOss*, XrdSysLogger *, const char *, const char *);
 static int DetermineEnvironment();
 
+XrdOss *g_hdfs_oss = NULL;
+
 extern "C"
 {
 
@@ -32,7 +34,11 @@ XrdOss *XrdOssGetStorageSystem(XrdOss       *native_oss,
                          const char         *config_fn,
                          const char         *parms)
 {
-   return Bootstrap(native_oss, Logger, config_fn, parms);
+   if (g_hdfs_oss) {return g_hdfs_oss;}
+
+   XrdOss *result = Bootstrap(native_oss, Logger, config_fn, parms);
+   if (result) {g_hdfs_oss = result;}
+   return result;
 }
 
 }

--- a/src/XrdHdfsChecksum.cc
+++ b/src/XrdHdfsChecksum.cc
@@ -1,0 +1,312 @@
+
+#include "XrdVersion.hh"
+
+#include "XrdHdfsChecksum.hh"
+
+XrdVERSIONINFO(XrdCksInit, XrdHdfsChecksum)
+
+using namespace XrdHdfs;
+class XrdSfsFileSystem;
+
+typedef std::pair<std::string, std::string> ChecksumValue;
+typedef std::vector<ChecksumValue> ChecksumValues;
+
+extern XrdOss *g_hdfs_oss;
+
+extern "C" {
+
+XrdCks *XrdCksInit(XrdSysError *eDest,
+                   const char *config_fn,
+                   const char *params)
+{
+    XrdCks *cks = new ChecksumManager(*eDest);
+    cks->Init(config_fn);
+    return cks;
+}
+
+}
+
+
+int
+ChecksumManager::GetFileContents(const char *pfn, std::string &result)
+{
+    if (!g_hdfs_oss) {return -ENOMEM;}
+
+    std::string checksum_path = GetChecksumFilename(pfn);
+
+    XrdOssDF *checksum_file = g_hdfs_oss->newFile();
+    if (!checksum_file) {return -ENOMEM;}
+
+    int rc = checksum_file->Open(checksum_path.c_str(), SFS_O_RDONLY, 0, XrdOucEnv &m_client);
+    if (rc)
+    {
+        return rc;
+    }
+
+    std::vector<char> read_buffer;
+    std::stringstream ss;
+    const int buffer_size = 4096;
+    read_buffer.resize(buffer_size);
+
+    int retval = 0;
+    off_t offset = 0;
+    do
+    {
+        do
+        {
+            errno = 0;  // Some versions of libhdfs forget to clear errno internally.
+            retval = g_hdfs_oss->Read(&read_buffer[0], offset, buffer_size-1);
+        }
+        while ((retval < 0) && errno == EINTR);
+
+        if (retval > 0)
+        {
+            read_buffer[retval] = '\0';
+            ss << &read_buffer[0];
+        }
+    }
+    while (retval > 0);
+    checksum_file->Close();
+    delete checksum_file;
+
+    if (retval < 0)
+    {
+        return retval;
+    }
+
+    contents = ss.str();
+
+    return 0;
+}
+
+
+int
+ChecksumManager::Parse(const std::string &chksum_contents, ChecksumValues &result)
+{
+    const char *ptr = cksum_contents.c_str();
+    std::vector<char> cksum;
+    cksum.resize(cksum_contents.size()+1);
+    unsigned int length = 0;
+    std::string cksum_value;
+
+    while (sscanf(ptr, "%s%n", &cksum[0], &length))
+    {
+        if (strlen(cksm) < 2)
+        {
+            m_log.Error("Too-short entry for checksum");
+            return -EIO;
+        }
+        val = strchr(&cksum[0], ':');
+        if (val == NULL)
+        {
+            m_log.Error("Invalid format of checksum entry.");
+            return -EIO;
+        }
+        *val = '\0';
+        val++;
+        if (*val == '\0')
+        {
+            m_log.Error("Checksum value not specified");
+            return -EIO;
+        }
+        ChecksumValue digest_and_val;
+        digest_and_val.first = &cksum[0];
+        digest_and_val.second = val;
+        result.push_back(digest_and_val);
+
+        ptr += length;
+        if (*ptr == '\0')
+        {
+            break;
+        }
+        if (*ptr != '\n')
+        {
+            // Error;
+            m_log.Error("Invalid format of checksum entry (Not a newline)");
+            return -EIO;
+        }
+        ptr += 1;
+        if (*ptr == '\0')
+        {
+            m_log.Error("Requested checksum type", requested_cksm, " not found.");
+            return -EIO;
+        }
+    }
+    return 0;
+}
+
+
+ChecksumManager::Init(const char * /*config_fn*/, const char *default_checksum = NULL)
+{
+    if (default_checksum)
+    {
+        m_default_digest = default_checksum'
+    }
+}
+
+std::string
+ChecksumManager::GetChecksumFilename(const char * pfn)
+{
+    if (!pfn) {return "";}
+
+    return "/cksums/" + pfn;
+}
+
+int
+ChecksumManager::Get(const char *pfn, XrdCksData &cks)
+{
+    std::string checksum_path = GetChecksumFilename(pfn);
+    const char *requested_checksum = cks.Name ? cks.Name : m_default_digest.c_str();
+    if (!strlen(requested_checksum))
+    {
+        requested_checksum = "adler32";
+    }
+
+    std::string cksum_contents;
+    int rc = GetFileContents(pfn, cksum_contents);
+    if (rc)
+    {
+        return rc;
+    }
+    ChecksumValues values;
+    rc = Parse(cksum_contents, values);
+    if (rc)
+    {
+        return rc;
+    }
+
+    for (ChecksumValues::const_iterator iter = values.begin();
+         iter != values.end();
+         iter++)
+    {
+        if (!strcasecmp(iter->first.c_str(), requested_checksum.c_str()))
+        {
+            cksm_value = iter->second;
+        }
+    }
+
+    if (!cksm_value.size()) {
+        Del(pfn, cks);
+        return -ESRCH;
+    }
+
+    std::stringstream ss2;
+    ss2 << "Got checksum (" << requested_cksm << ":" << cksm_value << ") for " << pfn;
+    m_log.Error(ss2.str().c_str());
+
+    if (cksm_value.size() > cks.ValuSize)
+    {
+        m_log.Error("Recorded checksum is too long for file:", pfn);
+        return -EDOM;
+    }
+    memcpy(cks.Value, cksm_value.c_str(), cksm_value.size());
+    cks.Length = cksm_value.size();
+
+    return 0;
+}
+
+
+int
+ChecksumManager::Del(const char *pfn, XrdCksData &cks)
+{
+    return g_hdfs_oss->Unlink(checksum_path.c_str());
+}
+
+
+int
+ChecksumManager::Config(const char *token, char *line)
+{
+    m_log.Error("Config variable passed", token, line);
+    return 1;
+}
+
+
+char *
+ChecksumManager::List(const char *pfn, char *buff, int blen, char seperator)
+{
+    std::string cksum_contents;
+    int rc = GetFileContents(pfn, cksum_contents);
+    if (rc)
+    {
+        return NULL;
+    }
+    ChecksumValues values;
+    rc = Parse(cksum_contents, values);
+    if (rc)
+    {
+        return NULL;
+    }
+
+    std::stringstream ss;
+    bool first_entry = true;
+    for (ChecksumValues::const_iterator iter = values.begin();
+         iter != values.end();
+         iter++)
+    {
+        if (first_entry)
+        {
+            first_entry = false;
+        }
+        else
+        {
+            ss << separator;
+        }
+        ss << values.first;
+    }
+    std::string result = ss.str();
+    size_t mem_to_copy = (blen < result.size()) ? blen : result.size();
+    memcpy(buff, result.c_str(), mem_to_copy);
+
+    return buff;
+}
+
+
+const char *
+ChecksumManager::Name(int seq_num)
+{
+    switch (seq_num)
+    {
+    case 0:
+        return "md5";
+    case 1:
+        return "adler32";
+    case 2:
+        return "cksum";
+    default:
+        return NULL;
+    }
+}
+
+
+int
+ChecksumManager::Ver(const char *pfn, XrdCksData &cks)
+{
+    XrdCksData cks_on_disk;
+    int rc = Get(pfn, cks_on_disk);
+    if (rc)
+    {
+        rc = Calc(pfn, cks_on_disk, 1);
+        if (rc)
+        {
+            return rc;
+        }
+    }
+
+    return !memcmp(cks_on_disk.Value, cks.Value, cks.Length) ? 0 : 1;
+}
+
+
+int
+ChecksumManager::Size(const char *name)
+{
+    if (!strcasecmp(name, "md5")) {return 16;}
+    else if (!strcasecmp(name, "adler32")) {return 5;}
+    else if (!strcasecmp(name, "cksum")) {return 5;}
+}
+
+
+int
+ChecksumManager::Set(const char *pfn, XrdCksData &cks, int mtime)
+{
+    
+}

--- a/src/XrdHdfsChecksum.cc
+++ b/src/XrdHdfsChecksum.cc
@@ -66,15 +66,15 @@ ChecksumManager::GetFileContents(const char *pfn, std::string &result) const
     {
         do
         {
-            errno = 0;  // Some versions of libhdfs forget to clear errno internally.
             retval = checksum_file->Read(&read_buffer[0], offset, buffer_size-1);
         }
-        while ((retval < 0) && errno == EINTR);
+        while (retval == -EINTR);
 
         if (retval > 0)
         {
             read_buffer[retval] = '\0';
             ss << &read_buffer[0];
+            offset += retval;
         }
     }
     while (retval > 0);

--- a/src/XrdHdfsChecksum.hh
+++ b/src/XrdHdfsChecksum.hh
@@ -1,0 +1,67 @@
+
+/*
+ * A checksum manager integrating with the Xrootd HDFS plugin.
+ */
+
+#include "XrdCks/XrdCks.hh"
+#include "hdfs.h"
+
+#include <vector>
+#include <string>
+
+class XrdSysError;
+class XrdOucEnv;
+
+namespace XrdHdfs {
+
+class ChecksumManager : public XrdCks
+{
+public:
+    ChecksumManager(XrdSysError &);
+
+    virtual int Calc(const char *pfn, XrdCksData &cks, int do_set=1) override;
+
+    virtual int Del(const char *pfn, XrdCksData &cks) override;
+
+    virtual int Get(const char *pfn, XrdCksData &cks) override;
+
+    virtual int Config(const char *token, char *line) override;
+
+    virtual int Init(const char *config_fn, const char *default_checksum = NULL) override;
+
+    virtual char *List(const char *pfn, char *buff, int blen, char seperator=' ') override;
+
+    virtual const char *Name(int seq_num) override;
+
+    virtual XrdCksCalc *Object(const char *name) override;
+
+    virtual int Size(const char *name=NULL) override;
+
+    virtual int Set(const char *pfn, XrdCksData &cks, int mtime=0) override;
+
+    virtual int Ver(const char *pfn, XrdCksData &cks);
+
+    virtual ~XrdCks() {}
+
+    enum ChecksumTypes {
+        MD5,
+        CKSUM,
+        ADLER32
+    };
+
+private:
+    typedef std::pair<std::string, std::string> ChecksumValue;
+    typedef std::vector<ChecksumValue> ChecksumValues;
+
+    XrdSysError &m_log;
+    XrdOucEnv &m_client;
+
+    std::string GetCksumFilename(const char *pfn) const;
+    int GetFileContents(const char * pfn, std::string &contents) const;
+    static int Parse(const std::string &chksum_contents, ChecksumValues &result);
+
+    std::string m_default_digest;
+};
+
+}
+

--- a/src/XrdHdfsChecksum.hh
+++ b/src/XrdHdfsChecksum.hh
@@ -29,7 +29,7 @@ public:
 
     void Finalize();
 
-    std::string Get(unsigned digest);
+    std::string Get(unsigned digest) const;
 
 private:
     ChecksumState(ChecksumState const &);
@@ -85,6 +85,8 @@ public:
     virtual int Size(const char *name=NULL);
 
     virtual int Set(const char *pfn, XrdCksData &cks, int mtime=0);
+
+    int Set(const char *pfn, const ChecksumState &state) const;
 
     virtual int Ver(const char *pfn, XrdCksData &cks);
 

--- a/src/XrdHdfsChecksum.hh
+++ b/src/XrdHdfsChecksum.hh
@@ -37,6 +37,7 @@ private:
     uint32_t m_cksum;
     uint32_t m_adler32;
 
+    unsigned m_md5_length;
     size_t m_cur_chunk_bytes;
     off_t m_offset;
 
@@ -103,8 +104,9 @@ private:
     XrdOucEnv m_client;
 
     std::string GetChecksumFilename(const char *pfn) const;
-    int GetFileContents(const char * pfn, std::string &contents) const;
+    int GetFileContents(const char *pfn, std::string &contents) const;
     int Parse(const std::string &chksum_contents, ChecksumValues &result);
+    int SetMultiple(const char *pfn, const ChecksumValues &values) const;
 
     std::string m_default_digest;
 };

--- a/src/XrdHdfsChecksum.hh
+++ b/src/XrdHdfsChecksum.hh
@@ -21,7 +21,7 @@ namespace XrdHdfs {
 class ChecksumState
 {
 public:
-    ChecksumState(unsigned digests);
+    explicit ChecksumState(unsigned digests);
 
     ~ChecksumState();
 
@@ -32,6 +32,9 @@ public:
     std::string Get(unsigned digest);
 
 private:
+    ChecksumState(ChecksumState const &);
+    ChecksumState & operator=(ChecksumState const &);
+
     const unsigned m_digests;
     uint32_t m_crc32;
     uint32_t m_cksum;

--- a/src/XrdHdfsChecksum.hh
+++ b/src/XrdHdfsChecksum.hh
@@ -6,8 +6,11 @@
 #include "XrdCks/XrdCks.hh"
 #include "hdfs.h"
 
+#include <cstdio>
 #include <vector>
 #include <string>
+
+#include "XrdOuc/XrdOucEnv.hh"
 
 class XrdSysError;
 class XrdOucEnv;
@@ -35,13 +38,13 @@ public:
 
     virtual XrdCksCalc *Object(const char *name) override;
 
-    virtual int Size(const char *name=NULL) override;
+    virtual int Size(const char *name=NULL);
 
-    virtual int Set(const char *pfn, XrdCksData &cks, int mtime=0) override;
+    virtual int Set(const char *pfn, XrdCksData &cks, int mtime=0);
 
     virtual int Ver(const char *pfn, XrdCksData &cks);
 
-    virtual ~XrdCks() {}
+    virtual ~ChecksumManager() {}
 
     enum ChecksumTypes {
         MD5,
@@ -54,11 +57,11 @@ private:
     typedef std::vector<ChecksumValue> ChecksumValues;
 
     XrdSysError &m_log;
-    XrdOucEnv &m_client;
+    XrdOucEnv m_client;
 
-    std::string GetCksumFilename(const char *pfn) const;
+    std::string GetChecksumFilename(const char *pfn) const;
     int GetFileContents(const char * pfn, std::string &contents) const;
-    static int Parse(const std::string &chksum_contents, ChecksumValues &result);
+    int Parse(const std::string &chksum_contents, ChecksumValues &result);
 
     std::string m_default_digest;
 };

--- a/src/XrdHdfsChecksumCalc.cc
+++ b/src/XrdHdfsChecksumCalc.cc
@@ -3,8 +3,14 @@
 using namespace XrdHdfs;
 
 
+XrdCksCalc *
+ChecksumManager::Object(const char * /*name*/)
+{
+    return NULL;
+}
+
 int
-ChecksumManager::Calc(const char *pfn, XrdCksData &cks)
+ChecksumManager::Calc(const char * /*pfn*/, XrdCksData & /*cks*/, int /* do_set */)
 {
     // TODO: migrate the checksum calculation routines from gridftp-hdfs!
     return 1;

--- a/src/XrdHdfsChecksumCalc.cc
+++ b/src/XrdHdfsChecksumCalc.cc
@@ -1,8 +1,245 @@
 #include "XrdHdfsChecksum.hh"
 
+#include <sstream>
+
+#include <zlib.h>
+#include <openssl/evp.h>
+
+#include "XrdOss/XrdOss.hh"
+#include "XrdSfs/XrdSfsInterface.hh"
+
 using namespace XrdHdfs;
 
+extern XrdOss *g_hdfs_oss;
 
+
+#define CVMFS_CHUNK_SIZE (24*1024*1024)
+
+// CRC32 table from the published POSIX standard
+static uint32_t const g_crctab[256] =
+{
+  0x00000000,
+  0x04c11db7, 0x09823b6e, 0x0d4326d9, 0x130476dc, 0x17c56b6b,
+  0x1a864db2, 0x1e475005, 0x2608edb8, 0x22c9f00f, 0x2f8ad6d6,
+  0x2b4bcb61, 0x350c9b64, 0x31cd86d3, 0x3c8ea00a, 0x384fbdbd,
+  0x4c11db70, 0x48d0c6c7, 0x4593e01e, 0x4152fda9, 0x5f15adac,
+  0x5bd4b01b, 0x569796c2, 0x52568b75, 0x6a1936c8, 0x6ed82b7f,
+  0x639b0da6, 0x675a1011, 0x791d4014, 0x7ddc5da3, 0x709f7b7a,
+  0x745e66cd, 0x9823b6e0, 0x9ce2ab57, 0x91a18d8e, 0x95609039,
+  0x8b27c03c, 0x8fe6dd8b, 0x82a5fb52, 0x8664e6e5, 0xbe2b5b58,
+  0xbaea46ef, 0xb7a96036, 0xb3687d81, 0xad2f2d84, 0xa9ee3033,
+  0xa4ad16ea, 0xa06c0b5d, 0xd4326d90, 0xd0f37027, 0xddb056fe,
+  0xd9714b49, 0xc7361b4c, 0xc3f706fb, 0xceb42022, 0xca753d95,
+  0xf23a8028, 0xf6fb9d9f, 0xfbb8bb46, 0xff79a6f1, 0xe13ef6f4,
+  0xe5ffeb43, 0xe8bccd9a, 0xec7dd02d, 0x34867077, 0x30476dc0,
+  0x3d044b19, 0x39c556ae, 0x278206ab, 0x23431b1c, 0x2e003dc5,
+  0x2ac12072, 0x128e9dcf, 0x164f8078, 0x1b0ca6a1, 0x1fcdbb16,
+  0x018aeb13, 0x054bf6a4, 0x0808d07d, 0x0cc9cdca, 0x7897ab07,
+  0x7c56b6b0, 0x71159069, 0x75d48dde, 0x6b93dddb, 0x6f52c06c,
+  0x6211e6b5, 0x66d0fb02, 0x5e9f46bf, 0x5a5e5b08, 0x571d7dd1,
+  0x53dc6066, 0x4d9b3063, 0x495a2dd4, 0x44190b0d, 0x40d816ba,
+  0xaca5c697, 0xa864db20, 0xa527fdf9, 0xa1e6e04e, 0xbfa1b04b,
+  0xbb60adfc, 0xb6238b25, 0xb2e29692, 0x8aad2b2f, 0x8e6c3698,
+  0x832f1041, 0x87ee0df6, 0x99a95df3, 0x9d684044, 0x902b669d,
+  0x94ea7b2a, 0xe0b41de7, 0xe4750050, 0xe9362689, 0xedf73b3e,
+  0xf3b06b3b, 0xf771768c, 0xfa325055, 0xfef34de2, 0xc6bcf05f,
+  0xc27dede8, 0xcf3ecb31, 0xcbffd686, 0xd5b88683, 0xd1799b34,
+  0xdc3abded, 0xd8fba05a, 0x690ce0ee, 0x6dcdfd59, 0x608edb80,
+  0x644fc637, 0x7a089632, 0x7ec98b85, 0x738aad5c, 0x774bb0eb,
+  0x4f040d56, 0x4bc510e1, 0x46863638, 0x42472b8f, 0x5c007b8a,
+  0x58c1663d, 0x558240e4, 0x51435d53, 0x251d3b9e, 0x21dc2629,
+  0x2c9f00f0, 0x285e1d47, 0x36194d42, 0x32d850f5, 0x3f9b762c,
+  0x3b5a6b9b, 0x0315d626, 0x07d4cb91, 0x0a97ed48, 0x0e56f0ff,
+  0x1011a0fa, 0x14d0bd4d, 0x19939b94, 0x1d528623, 0xf12f560e,
+  0xf5ee4bb9, 0xf8ad6d60, 0xfc6c70d7, 0xe22b20d2, 0xe6ea3d65,
+  0xeba91bbc, 0xef68060b, 0xd727bbb6, 0xd3e6a601, 0xdea580d8,
+  0xda649d6f, 0xc423cd6a, 0xc0e2d0dd, 0xcda1f604, 0xc960ebb3,
+  0xbd3e8d7e, 0xb9ff90c9, 0xb4bcb610, 0xb07daba7, 0xae3afba2,
+  0xaafbe615, 0xa7b8c0cc, 0xa379dd7b, 0x9b3660c6, 0x9ff77d71,
+  0x92b45ba8, 0x9675461f, 0x8832161a, 0x8cf30bad, 0x81b02d74,
+  0x857130c3, 0x5d8a9099, 0x594b8d2e, 0x5408abf7, 0x50c9b640,
+  0x4e8ee645, 0x4a4ffbf2, 0x470cdd2b, 0x43cdc09c, 0x7b827d21,
+  0x7f436096, 0x7200464f, 0x76c15bf8, 0x68860bfd, 0x6c47164a,
+  0x61043093, 0x65c52d24, 0x119b4be9, 0x155a565e, 0x18197087,
+  0x1cd86d30, 0x029f3d35, 0x065e2082, 0x0b1d065b, 0x0fdc1bec,
+  0x3793a651, 0x3352bbe6, 0x3e119d3f, 0x3ad08088, 0x2497d08d,
+  0x2056cd3a, 0x2d15ebe3, 0x29d4f654, 0xc5a92679, 0xc1683bce,
+  0xcc2b1d17, 0xc8ea00a0, 0xd6ad50a5, 0xd26c4d12, 0xdf2f6bcb,
+  0xdbee767c, 0xe3a1cbc1, 0xe760d676, 0xea23f0af, 0xeee2ed18,
+  0xf0a5bd1d, 0xf464a0aa, 0xf9278673, 0xfde69bc4, 0x89b8fd09,
+  0x8d79e0be, 0x803ac667, 0x84fbdbd0, 0x9abc8bd5, 0x9e7d9662,
+  0x933eb0bb, 0x97ffad0c, 0xafb010b1, 0xab710d06, 0xa6322bdf,
+  0xa2f33668, 0xbcb4666d, 0xb8757bda, 0xb5365d03, 0xb1f740b4
+};
+
+
+static std::string
+human_readable_evp(unsigned char *evp, size_t length)
+{
+    unsigned int idx;
+    std::string result; result.resize(length*2);
+    for (idx = 0; idx < length; idx++)
+    {
+        char encoded[2];
+        sprintf(encoded, "%02x", evp[idx]);
+        result += encoded;
+    }
+    return result;
+}
+
+
+ChecksumState::ChecksumState(unsigned digests)
+    : m_digests(digests),
+      m_cksum(0),
+      m_adler32(adler32(0, NULL, 0)),
+      m_cur_chunk_bytes(0),
+      m_offset(0),
+      m_md5(NULL),
+      m_file_sha1(NULL),
+      m_chunk_sha1(NULL)
+{
+    if (digests & ChecksumManager::MD5)
+    {
+        m_md5 = EVP_MD_CTX_create();
+        EVP_DigestInit_ex(m_md5, EVP_md5(), NULL);
+    }
+    if (digests & ChecksumManager::CVMFS)
+    {
+        m_file_sha1 = EVP_MD_CTX_create();
+        EVP_DigestInit_ex(m_file_sha1, EVP_sha1(), NULL);
+        m_chunk_sha1 = EVP_MD_CTX_create();
+        EVP_DigestInit_ex(m_chunk_sha1, EVP_sha1(), NULL);
+    }
+}
+
+
+ChecksumState::~ChecksumState()
+{
+    if (m_md5)
+    {
+        EVP_MD_CTX_destroy(m_md5);
+    }
+    if (m_file_sha1)
+    {
+        EVP_MD_CTX_destroy(m_file_sha1);
+    }
+    if (m_chunk_sha1)
+    {
+        EVP_MD_CTX_destroy(m_chunk_sha1);
+    }
+}
+
+
+void
+ChecksumState::Update(const unsigned char *buffer, size_t bsize)
+{
+    m_offset += bsize;
+    if (m_digests & ChecksumManager::ADLER32)
+    {
+        m_adler32 = adler32(m_adler32, buffer, bsize);
+    }
+    if (m_digests & ChecksumManager::CKSUM)
+    {
+        size_t bytes_remaining = bsize;
+        const unsigned char *current_buffer = buffer;
+        uint32_t crc = m_cksum;
+        while (bytes_remaining--) {
+            crc = (crc << 8) ^ g_crctab[((crc >> 24) ^ *current_buffer++) & 0xFF];
+        }
+        m_cksum = crc;
+    }
+    if (m_digests & ChecksumManager::CRC32)
+    {
+        m_crc32 = crc32(m_crc32, buffer, bsize);
+    }
+    if (m_digests & ChecksumManager::MD5)
+    {
+        EVP_DigestUpdate(m_md5, buffer, bsize);
+    }
+    if (m_digests & ChecksumManager::CVMFS)
+    {
+        EVP_DigestUpdate(m_file_sha1, buffer, bsize);
+        off_t total_bytes = m_cur_chunk_bytes + bsize;
+        size_t buffer_offset = 0;
+        while (total_bytes >= CVMFS_CHUNK_SIZE) {  // There are at least CVMFS_CHUNK_SIZE bytes to write!
+            size_t new_bytes = CVMFS_CHUNK_SIZE - m_cur_chunk_bytes;
+            EVP_DigestUpdate(m_chunk_sha1, buffer + buffer_offset, new_bytes);
+            buffer_offset += new_bytes;
+            bsize-= new_bytes;
+
+            // Create a new chunk.
+            unsigned char sha1_value[EVP_MAX_MD_SIZE];
+            unsigned int sha1_len;
+            EVP_DigestFinal_ex(m_chunk_sha1, sha1_value, &sha1_len);
+            EVP_DigestInit_ex(m_chunk_sha1, EVP_sha1(), NULL);
+            CvmfsChunk new_chunk;
+            new_chunk.m_offset = (m_chunks.size() == 0) ? 0 : (m_chunks.back().m_offset + CVMFS_CHUNK_SIZE);
+            new_chunk.m_sha1 = human_readable_evp(sha1_value, sha1_len);
+            m_chunks.push_back(new_chunk);
+
+            m_cur_chunk_bytes = 0;
+            total_bytes -= CVMFS_CHUNK_SIZE;
+        }
+        EVP_DigestUpdate(m_chunk_sha1, buffer + buffer_offset, bsize);
+        m_cur_chunk_bytes += bsize;
+    }
+}
+
+
+void
+ChecksumState::Finalize()
+{
+    if (m_digests & ChecksumManager::MD5)
+    {
+        EVP_DigestFinal_ex(m_md5, m_md5_value, NULL);
+        EVP_MD_CTX_destroy(m_md5);
+    }
+    if (m_digests & ChecksumManager::CVMFS)
+    {
+        unsigned char sha1_value[EVP_MAX_MD_SIZE];
+        unsigned int sha1_len;
+        EVP_DigestFinal_ex(m_file_sha1, sha1_value, &sha1_len);
+        EVP_MD_CTX_destroy(m_file_sha1);
+        m_sha1_final = human_readable_evp(sha1_value, sha1_len);
+
+        off_t chunk_offset = m_offset - m_cur_chunk_bytes;
+        if (m_cur_chunk_bytes && chunk_offset)
+        {
+            CvmfsChunk new_chunk;
+            new_chunk.m_offset = chunk_offset;
+            EVP_DigestFinal_ex(m_chunk_sha1, sha1_value, &sha1_len);
+            new_chunk.m_sha1 = human_readable_evp(sha1_value, sha1_len);
+        }
+        EVP_MD_CTX_destroy(m_chunk_sha1);
+
+        std::stringstream ss;
+        ss << "size=" << m_offset << ";checksum=" << m_sha1_final;
+        if (m_chunks.size() < 2)
+        {
+            ss << ";chunk_offsets=0;chunk_checksums=" << m_sha1_final;
+        }
+        else
+        {
+            ss << ";chunk_offsets=0";
+            for (unsigned idx = 1; idx < m_chunks.size(); idx++)
+            {
+                ss << "," << m_chunks[idx].m_offset;
+            }
+            ss << ";chunk_checksums=" << m_chunks[0].m_sha1;
+            for (unsigned idx = 1; idx < m_chunks.size(); idx++)
+            {
+                ss << "," << m_chunks[idx].m_sha1;
+            }
+        }
+        m_graft = ss.str();
+    }
+}
+
+
+/*
+ * Note - it is not apparent this is ever used, hence it is
+ * just a stub in this implementation.
+ */
 XrdCksCalc *
 ChecksumManager::Object(const char * /*name*/)
 {
@@ -10,8 +247,72 @@ ChecksumManager::Object(const char * /*name*/)
 }
 
 int
-ChecksumManager::Calc(const char * /*pfn*/, XrdCksData & /*cks*/, int /* do_set */)
+ChecksumManager::Calc(const char *pfn, XrdCksData &cks, int do_set)
 {
-    // TODO: migrate the checksum calculation routines from gridftp-hdfs!
-    return 1;
+    int digests = 0;
+    if (do_set)
+    {
+        digests = ChecksumManager::ALL;
+    }
+    else if (!strncasecmp(cks.Name, "md5", cks.NameSize))
+    {
+        digests = ChecksumManager::MD5;
+    }
+    else if (!strncasecmp(cks.Name, "cksum", cks.NameSize))
+    {
+        digests = ChecksumManager::CKSUM;
+    }
+    else if (!strncasecmp(cks.Name, "crc32", cks.NameSize))
+    {
+        digests = ChecksumManager::CRC32;
+    }
+    else if (!strncasecmp(cks.Name, "adler32", cks.NameSize))
+    {
+        digests = ChecksumManager::ADLER32;
+    }
+    else
+    {
+        return -ENOTSUP;
+    }
+
+    if (!g_hdfs_oss) {return -ENOMEM;}
+
+    XrdOssDF *fh = g_hdfs_oss->newFile("checksum_calc");
+    if (!fh) {return -ENOMEM;}
+    int rc = fh->Open(pfn, SFS_O_RDONLY, 0, m_client);
+    if (rc)
+    {
+        return rc;
+    }
+
+    ChecksumState state(digests);
+
+    const static int buffer_size = 256*1024;
+    std::vector<unsigned char> read_buffer;
+    read_buffer.resize(buffer_size);
+
+    int retval = 0;
+    off_t offset = 0;
+    do
+    {
+        do
+        {
+            retval = fh->Read(&read_buffer[0], offset, buffer_size);
+        }
+        while (retval == -EINTR);
+
+        if (retval > 0)
+        {
+            state.Update(&read_buffer[0], retval);
+            offset += retval;
+        }
+    }
+    while (retval > 0);
+    fh->Close();
+    delete fh;
+
+    state.Finalize();
+
+    // TODO: actually fill in the requested checksum.
+    return -ENOTSUP;
 }

--- a/src/XrdHdfsChecksumCalc.cc
+++ b/src/XrdHdfsChecksumCalc.cc
@@ -1,0 +1,11 @@
+#include "XrdHdfsChecksum.hh"
+
+using namespace XrdHdfs;
+
+
+int
+ChecksumManager::Calc(const char *pfn, XrdCksData &cks)
+{
+    // TODO: migrate the checksum calculation routines from gridftp-hdfs!
+    return 1;
+}

--- a/src/export-lib-symbols
+++ b/src/export-lib-symbols
@@ -1,0 +1,8 @@
+{
+global:
+  XrdOssGetStorageSystem*;
+  XrdCksInit*;
+
+local:
+  *;
+};


### PR DESCRIPTION
This PR adds support for HDFS-style checksums.  Not only do checksums get calculated on file writing (stored into the same location as GridFTP does), but they can also be queried via Xrootd if `libXrdHdfs.so` is loaded as a checksum plugin with the following configuration commands:

```
ofs.ckslib * libXrdHdfs.so
xrootd.chksum max 2 md5 adler32 crc32
```

Fixes #13 