### PR TITLE
Pass through LFN2PFN calls.

### DIFF
--- a/src/XrdHdfs.cc
+++ b/src/XrdHdfs.cc
@@ -863,6 +863,21 @@ XrdHdfsSys::GetRealPath(const char *path)
    return fname;
 }
 
+int XrdHdfsSys::Lfn2Pfn(const char *oldp, char *newp, int blen)
+{
+    if (the_N2N) return -(the_N2N->lfn2pfn(oldp, newp, blen));
+    if ((int)strlen(oldp) >= blen) return -ENAMETOOLONG;
+    strcpy(newp, oldp);
+    return 0;
+}
+
+const char *XrdHdfsSys::Lfn2Pfn(const char *oldp, char *newp, int blen, int &rc)
+{
+    if (!the_N2N) {rc = 0; return oldp;}
+    if ((rc = -(the_N2N->lfn2pfn(oldp, newp, blen)))) return 0;
+    return newp;
+}
+
 /******************************************************************************/
 /*                                  S t a t                                   */
 /******************************************************************************/

--- a/src/XrdHdfs.hh
+++ b/src/XrdHdfs.hh
@@ -203,6 +203,9 @@ static  int            Emsg(const char *, XrdOucErrInfo&, int, const char *x,
 
 char * GetRealPath(const char *);  // Given a requested pathname, translate it to the HDFS path.  Caller must free() returned space.
 
+virtual int            Lfn2Pfn(const char *Path, char *buff, int blen);
+virtual const char    *Lfn2Pfn(const char *Path, char *buff, int blen, int &rc);
+
 XrdHdfsSys() : XrdOss() {}
 virtual ~XrdHdfsSys() {}
 


### PR DESCRIPTION
Implementation appears to be necessary in order for checksums to be passed through with a working N2N.