### PR TITLE
Enable checksum recomputation

### DIFF
--- a/src/XrdHdfsChecksum.cc
+++ b/src/XrdHdfsChecksum.cc
@@ -191,7 +191,9 @@ ChecksumManager::Get(const char *pfn, XrdCksData &cks)
     rc = Parse(checksum_contents, values);
     if (rc)
     {
-        return rc;
+        // Override the error code and return -ESRCH; in this case,
+        // XRootD will recompute the checksum.
+        return -ESRCH;
     }
 
     std::string checksum_value;

--- a/src/XrdHdfsChecksum.cc
+++ b/src/XrdHdfsChecksum.cc
@@ -7,6 +7,7 @@
 
 #include "XrdOss/XrdOss.hh"
 #include "XrdSfs/XrdSfsInterface.hh"
+#include "XrdSec/XrdSecEntity.hh"
 #include "XrdSys/XrdSysError.hh"
 
 XrdVERSIONINFO(XrdCksInit, XrdHdfsChecksum)
@@ -36,8 +37,10 @@ XrdCks *XrdCksInit(XrdSysError *eDest,
 
 ChecksumManager::ChecksumManager(XrdSysError& log)
     : XrdCks(&log),
-      m_log(log)
+      m_log(log),
+      m_client(0, 0, &m_client_sec)
 {
+     m_client_sec.name = strdup("root");
 }
 
 

--- a/src/XrdHdfsChecksum.hh
+++ b/src/XrdHdfsChecksum.hh
@@ -12,6 +12,7 @@
 #include <string>
 
 #include "XrdOuc/XrdOucEnv.hh"
+#include "XrdSec/XrdSecEntity.hh"
 
 class XrdSysError;
 class XrdOucEnv;
@@ -106,6 +107,7 @@ private:
     typedef std::vector<ChecksumValue> ChecksumValues;
 
     XrdSysError &m_log;
+    XrdSecEntity m_client_sec;
     XrdOucEnv m_client;
 
     std::string GetChecksumFilename(const char *pfn) const;


### PR DESCRIPTION
In the case where checksum files are present but not parseable (perhaps a corruption occurred?), we should respond with `-ESRCH`.  This particular return value indicates to XRootD that the checksum is not available and should be calculated.

Additionally, this creates a `XrdSecEntity` object to be used for the checksum computations.  Instead of using a `NULL` entity (which maps to user `nobody`, who may not have the ability to read the file to be checksummed), we use the `root` super-user to allow us to bypass DACs.