### PR TITLE
making hdfs opt in since osg-xrootd brings it by default

### DIFF
--- a/configs/config.d/40-xrootd-hdfs.cfg
+++ b/configs/config.d/40-xrootd-hdfs.cfg
@@ -8,6 +8,7 @@
 #
 
 # Enable checksum verification
-ofs.ckslib * /usr/lib64/libXrdHdfs.so
-
-ofs.osslib /usr/lib64/libXrdHdfs.so
+if ?EnableHDFS
+   ofs.ckslib * /usr/lib64/libXrdHdfs.so
+   ofs.osslib /usr/lib64/libXrdHdfs.so
+fi


### PR DESCRIPTION
Since `osg-xrootd-standalone` brings xrootd-hdfs by defualt but not all xrootd standalone server use hdfs we need an opt in.