### PR TITLE
use versioned name for libXrdHdfsReal .so (SOFTWARE-3329)

### DIFF
--- a/src/XrdHdfsBootstrap.cc
+++ b/src/XrdHdfsBootstrap.cc
@@ -82,7 +82,8 @@ static XrdOss *Bootstrap(XrdOss *native_oss,XrdSysLogger *Logger, const char *co
    loadJvm();
  
    HdfsBootstrapEroute.logger(Logger);
-   if (!(myLib = new XrdSysPlugin(&HdfsBootstrapEroute, "libXrdHdfsReal.so"))) return 0;
+   myLib = new XrdSysPlugin(&HdfsBootstrapEroute, "libXrdHdfsReal-" XRDPLUGIN_SOVERSION ".so");
+   if (!myLib) return 0;
 
 // Now get the entry point of the object creator
 //


### PR DESCRIPTION
xrootd-hdfs now ships a `libXrdHdfsReal-<XRD_MAJOR>.so` instead of `libXrdHdfsReal.so`, so this place where it was loading the latter name is broken.

This could be fixed by making a symlink, `libXrdHdfsReal.so` -> `libXrdHdfsReal-<XRD_MAJOR>.so`, but it seems a bit more correct just to load the correct one.

Feel free to add an appropriate reviewer.

Scratch build succeeded:
https://koji.opensciencegrid.org/koji/taskinfo?taskID=321088

I verified that the new `/usr/lib64/libXrdHdfs-4.so.0.0.1` from this scratch build contains the string `libXrdHdfsReal-4.so` where the currently released xrootd-hdfs-2.1.7-8.osg35.el7 has `libXrdHdfsReal.so`.  So i believe this fix is working as expected.