### PR TITLE
Advertise that AIO is not supported

### DIFF
--- a/src/XrdHdfs.cc
+++ b/src/XrdHdfs.cc
@@ -695,6 +695,7 @@ int XrdHdfsFile::Read(XrdSfsAio *aiop)
 {
 
 // Execute this request in a synchronous fashion
+// Will not be called as XrdHdfsSys::Features() advertises no AIO support.
 //
    aiop->Result = this->Read((void *)aiop->sfsAio.aio_buf, aiop->sfsAio.aio_offset,
                              aiop->sfsAio.aio_nbytes);
@@ -752,6 +753,7 @@ int XrdHdfsFile::Write(XrdSfsAio *aiop)
 {
 
 // Execute this request in a synchronous fashion
+// Will not be called as XrdHdfsSys::Features() advertises no AIO support.
 //
    aiop->Result = this->Write((const char *)aiop->sfsAio.aio_buf, aiop->sfsAio.aio_offset,
                               aiop->sfsAio.aio_nbytes);

--- a/src/XrdHdfs.hh
+++ b/src/XrdHdfs.hh
@@ -173,6 +173,9 @@ public:
         int            Create(const char *, const char *, mode_t, XrdOucEnv &,
                               int opts=0);
 
+        uint64_t       Features()  // Turn async I/O off for hdfs
+                       {return XRDOSS_HASNAIO;}
+
         int            Init(XrdSysLogger *, const char *);
 
         int            getStats(char *buff, int blen) {return 0;}


### PR DESCRIPTION
Fixes a crash on 5.3.0 with xrootd.async enabled  (default).