### PR TITLE
Fix gfal-rename by ensuring user name is not blank and update to 2.3.1-1.

### DIFF
--- a/rpm/xrootd-hdfs.spec
+++ b/rpm/xrootd-hdfs.spec
@@ -1,6 +1,6 @@
 Name: xrootd-hdfs
-Version: 2.3.0
-Release: 3%{?dist}
+Version: 2.3.1
+Release: 1%{?dist}
 Summary: HDFS plugin for xrootd
 
 Group: System Environment/Development
@@ -82,6 +82,9 @@ rm $RPM_BUILD_ROOT%{_bindir}/xrootd_hdfs_envcheck
 %{_includedir}/XrdHdfs.hh
 
 %changelog
+* Fri Feb 07 2025 Carl Vuosalo <covuosalo@wisc.edu> - 2.3.1-1
+- Fix user name bug that caused gfal-rename to fail.
+
 * Wed Feb 14 2024 Chad Seys <cwseys@physics.wisc.edu> - 2.3.0-3
 - new location of libjvm.so for java-11 in EL8/9
 - use new cmake macros as indicated by

--- a/src/XrdHdfs.cc
+++ b/src/XrdHdfs.cc
@@ -90,7 +90,10 @@ ExtractAuthName(const XrdOucEnv *client)
     if (client && (sec = client->secEnv()))
     {
         std::string username;
-        return sec->eaAPI->Get("request.name", username) ? username : (sec->name ? sec->name : "nobody");
+        if (sec->eaAPI->Get("request.name", username) && username.length() > 1)
+	// Ensure username is not blank.
+           return username;
+        return sec->name ? sec->name : "nobody";
     }
     else
     {


### PR DESCRIPTION
`gfal-rename` was failing because a blank user name was being passed for such requests. This PR adds a check for a blank user name and, in that case, fetches the user name by different method.

This PR fixes issue #42.

This PR also updates the RPM version number to 2.3.1-1.